### PR TITLE
Improve error alert messages in form builder

### DIFF
--- a/picks.gs
+++ b/picks.gs
@@ -3740,7 +3740,7 @@ function launchFormBuilder() {
     }
   } catch (err) {
     Logger.log(`⚠️ Error starting form creation: ${err.stack}`);
-    ui.alert(`An error occurred while launching the form builder.`,`⚠️ FORM BUILD ERROR`);
+    ui.alert(`⚠️ FORM BUILD ERROR`,`An error occurred while launching the form builder:\n\n${err.message}`,ui.ButtonSet.OK);
   }
 }
 
@@ -3768,7 +3768,7 @@ function templateCreationPrompt(ss,ui) {
       ss.toast('Form creation canceled by user when running a form building operation',`⛔ FORM CREATION CANCELED`);
       Logger.log(`⛔ Form creation canceled by user`);
     } else {
-      ui.alert(`An unexpected error occurred: ${err.message}`,`⚠️ FORM BUILD ERROR`);
+    ui.alert(`⚠️ FORM BUILD ERROR`,`An unexpected error occurred:\n\n${err.message}`,ui.ButtonSet.OK);
       Logger.log(`⚠️ Error occurred during form building process: ${err.stack}`);
     }
   }


### PR DESCRIPTION
Both of these call Ui.alert(message, title). Ui.alert only accepts (prompt), (prompt, buttons), or (title, prompt, buttons) — there's no two-string overload, so the alert itself throws.

Because both sit in catch blocks, the effect is that the real exception never gets shown. I hit this running Form Builder: the dialog I got was "The parameters (String,String) don't match the method signature for Ui.alert", which is the error handler failing rather than the actual error. It took a while to work out what had really gone wrong.

This swaps the arguments into (title, prompt, buttons) order and adds ui.ButtonSet.OK. I also interpolated ${err.message} into the first one so the underlying error is visible, which is the whole point of that handler.