### PR TITLE
Fix templateForm check before logging

### DIFF
--- a/picks.gs
+++ b/picks.gs
@@ -3751,8 +3751,8 @@ function templateCreationPrompt(ss,ui) {
   ui = ui || fetchUi();
   try {
     const templateForm = getTemplateForm();
+       if (!templateForm) return;
     Logger.log(`📄 Template Form ${templateForm.getId()}`);
-    if (!templateForm) return;
 
     let response = ui.alert(
       '🎨 Customize Form Theme (One Time Only)',


### PR DESCRIPTION
In templateCreationPrompt(), templateForm.getId() is called one line before the `if (!templateForm) return;` guard, so the guard can never do its job.

Not reachable today — getTemplateForm() always returns a Form or throws — but its docstring says it can return null when the user cancels, so the ordering would bite if that ever became true. Just swaps the two lines.