### PR TITLE
Fix two bugs in leaderboardSheet: off-by-one row loop and malformed R1C1 reference

### DIFF
--- a/picks.gs
+++ b/picks.gs
@@ -8181,7 +8181,7 @@ function leaderboardSheet(ss, config, memberData) {
   // -------------------------------------------------------------
   let r;
   let firstColLetter = firstCell.getA1Notation().match(/^[A-Z]+/)[0];
-  for (let a = 0; a < (dataEndRow - dataStartRow); a++) {
+  for (let a = 0; a <= (dataEndRow - dataStartRow); a++) {
     r = a + dataStartRow;
     const playerCell = firstColLetter + r;
     

--- a/picks.gs
+++ b/picks.gs
@@ -8264,7 +8264,7 @@ function leaderboardSheet(ss, config, memberData) {
   // B. Completed Matchup Headers Dimming
   const matchupHeadersRange = sheet.getRange(matchupRow, firstMatchupCol, 1, maxWeeklyGames);
   const completedMatchupRule = SpreadsheetApp.newConditionalFormatRule()
-    .whenFormulaSatisfied(`=NOT(ISBLANK(R${effectiveOutcomeRow}C}C[0]))`)
+    .whenFormulaSatisfied(`=NOT(ISBLANK(R${effectiveOutcomeRow}C[0]))`)
     .setBackground('#37474F')
     .setFontColor('#80CBC4')
     .setRanges([matchupHeadersRange])


### PR DESCRIPTION
Two small bugs from 5c94ecb, both in `leaderboardSheet`. Since that function isn't wired to a menu yet I assume it's still in progress — feel free to fold these in wherever it fits.

### 1. The weekly-lookup loop skips the last member

`picks.gs:8184`

```js
for (let a = 0; a < (dataEndRow - dataStartRow); a++) {
```

`dataEndRow = dataStartRow + totalMembers - 1`, so this iterates `totalMembers - 1` times and the final member's row never gets any formulas — season totals, weekly lookups, sparkline, tiebreaker, comments, and the picks spill are all missing for that row.

`dataEndRow` is treated as inclusive everywhere else in the function (`adjustRows(sheet, dataEndRow + 2)`, `R${dataStartRow}C[0]:R${dataEndRow}C[0]`, and the `MAX(...)` ranges in the sparkline), so I assumed inclusive was the intent here too and changed `<` to `<=`. `a < totalMembers` would be equivalent if you'd rather read it that way.

### 2. Malformed R1C1 reference in the completed-matchup format rule

`picks.gs:8267`

```js
.whenFormulaSatisfied(`=NOT(ISBLANK(R${effectiveOutcomeRow}C}C[0]))`)
```

The `C}` looks like a paste artifact — it emits `R4C}C[0]`, so the rule never fires and completed matchup headers don't dim. It was `C[0]` before the rework.

### Two other things I noticed but didn't touch

Not changing these since I can't tell whether they're intentional:

- The `config.pickemsInclude` guard around the ⭐/🥇 columns was dropped in the rework. In a survivor-only pool `TOT_PICKS` and `TOT_RANK` are never created by `summarySheet` (they're inside the `pickemsInclude` block at line 7614), so those two columns come out empty rather than being omitted. `IFERROR` hides it, so it's cosmetic.
- Line 7965, `sheet.getRange(firstRow, 4).setValue('Sort:'); // Moving`, writes into the range that later gets merged as SEASON & POOL TOTALS — looks like a leftover from moving the control to A3.

Also worth mentioning: switching the season lookups to `TOT_NAME` / `TOT_*` is a real fix on its own. The previous version referenced `SUMMARY_NAMES`, which doesn't exist anywhere in the file, so those columns were silently blank behind the `IFERROR`.
